### PR TITLE
Solves bug related to fitting using __curve_fit with x errors

### DIFF
--- a/qexpy/fitting/fitting.py
+++ b/qexpy/fitting/fitting.py
@@ -255,7 +255,7 @@ def __curve_fit(fit_func, xdata, ydata, parguess, yerr) -> RawFitResults:
             func = __combine_fit_func_and_fit_params(fit_func, popt)
             yerr = 0 if yerr is None else yerr
             adjusted_yerr = np.sqrt(
-                yerr ** 2 + xdata.errors * utils.numerical_derivative(func, xdata.errors))
+                yerr ** 2 + (xdata.errors * utils.numerical_derivative(func, xdata.errors))**2)
 
             # re-calculate the fit with adjusted uncertainties for ydata
             popt, pcov = opt.curve_fit(  # pylint:disable=unbalanced-tuple-unpacking


### PR DESCRIPTION
When fitting to custom functions through the `__curve_fit` method, if the data includes x errors and the function is decreasing, the errors on the parameters will decrease as the x errors increase until the method returns the following error: 
`RuntimeError: Optimal parameters not found: Number of calls to function has reached maxfev = 600.`

The following code was used to test this as well as my fix;
```python
import numpy as np
import qexpy as q

def fit(x, *p):
    return p[0] + p[1]*x

y = q.MeasurementArray(np.array([100, 80, 60, 40, 20, 0])+np.random.normal(loc=0,scale=5,size=6), error = 5)

x1 = q.MeasurementArray([0, 1, 2, 3, 4, 5], error= 0)
x2 = q.MeasurementArray([0, 1, 2, 3, 4, 5], error= 5)

print("x1: ", x1)
results1 = q.fit(xdata=x1, ydata = y, model=fit, parguess=[100, -20])
print(results1)
print()
print("x2: ", x2)
results2 = q.fit(xdata=x2, ydata = y, model=fit, parguess=[100, -20])
print(results2)
```

It may be a good idea to use scipy.odr instead when there are x errors.